### PR TITLE
fix service dependency name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     image: minio/console:latest
     command: server
     depends_on:
-      - s3-dev
+      - s3
     networks:
       - fakews
     environment:


### PR DESCRIPTION
fix service dependency name to avoid error when running `docker-compose up`